### PR TITLE
Stats and api keys

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,9 +2,9 @@ name: Haskell CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/geocode-city-api.cabal
+++ b/geocode-city-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f4ca3a6260ee8372fb6b02ee659d98b163603a771dcaf9da297ebb9c29eab318
+-- hash: 6c1737b57e041bdbc6f8f246421008943a7806ca6b57c8914c33fd5e9bc9f6eb
 
 name:           geocode-city-api
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Effects.Database
       Effects.Log
       Import
+      Server.Auth
       Server.Handlers
       Server.Run
       Server.Types
@@ -48,6 +49,7 @@ library
       aeson
     , base >=4.11 && <10
     , bytestring
+    , containers
     , envy
     , fused-effects >=1.1.1.0 && <1.2
     , http-api-data
@@ -78,6 +80,7 @@ executable geocode-city-api-exe
       aeson
     , base >=4.11 && <10
     , bytestring
+    , containers
     , envy
     , fused-effects >=1.1.1.0 && <1.2
     , geocode-city-api
@@ -114,6 +117,7 @@ test-suite geocode-city-api-test
     , aeson
     , base >=4.11 && <10
     , bytestring
+    , containers
     , envy
     , fused-effects >=1.1.1.0 && <1.2
     , geocode-city-api

--- a/geocode-city-api.cabal
+++ b/geocode-city-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7310485dcbb46f32badc98100945f324bb27e7501d1533f8c7af79264325db5d
+-- hash: f4ca3a6260ee8372fb6b02ee659d98b163603a771dcaf9da297ebb9c29eab318
 
 name:           geocode-city-api
 version:        0.1.0.0
@@ -30,6 +30,7 @@ library
       Config
       Database.Migrations
       Database.Pool
+      Database.Queries
       Effects
       Effects.Database
       Effects.Log

--- a/migrations/202101191900_api_keys_table.sql
+++ b/migrations/202101191900_api_keys_table.sql
@@ -1,0 +1,40 @@
+create schema if not exists account;
+
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE OR REPLACE FUNCTION create_timestamps()   
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.created_at = now();
+            NEW.updated_at = now();
+            RETURN NEW;   
+        END;
+        $$ language 'plpgsql';
+
+CREATE OR REPLACE FUNCTION update_timestamps()   
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.updated_at = now();
+            RETURN NEW;   
+        END;
+        $$ language 'plpgsql';
+
+
+create table if not exists account.api_key
+  (
+    id bigint generated always as identity primary key,
+    key citext unique not null,
+    owner_email citext unique not null,
+    owner_name text not null,
+    is_enabled boolean not null,
+    created_at timestamp with time zone default current_timestamp not null,
+    updated_at timestamp with time zone default current_timestamp not null
+  );
+
+drop trigger if exists account_api_key_insert on account.api_key;
+  create trigger account_api_key_insert before insert on account.api_key for each row execute procedure create_timestamps();
+drop trigger if exists account_api_key_update on account.api_key;
+  create trigger account_api_key_update before update on account.api_key for each row execute procedure update_timestamps();
+
+
+create index if not exists idx_enabled_key on account.api_key(key, is_enabled);

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ dependencies:
 - bytestring
 - optparse-applicative
 - resource-pool ^>= 0.2.3.2
+- containers
 
 ghc-options:
 - -Wall

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -1,0 +1,31 @@
+module Database.Queries where
+
+import Data.Time
+import Database.PostgreSQL.Simple.Types (Only (..))
+import Effects
+import Import
+
+cityCount :: Has Database sig m => m Int
+cityCount = do
+  counts <- query_ "select count(geonameid) from geocode.city"
+  case counts of
+    [] -> pure 0
+    [Only c] -> pure c
+    (Only x) : _xs -> pure x
+
+latestUpdate :: Has Database sig m => m (Maybe Day)
+latestUpdate = do
+  updatedAts <- query_ "select max(modification) from raw.geonames"
+  case updatedAts of
+    [] -> pure Nothing
+    [Only u] -> pure u
+    (Only u : _xs) -> pure u
+
+{- to run queries manually:
+-- stack ghci
+λ> let (DatabaseUrl url) = defaultConfig & appDatabaseUrl
+λ> conn <- PG.connectPostgreSQL $ encodeUtf8 url
+λ> runDatabaseWithConnection conn $ Database.Queries.cityCount 
+196591
+
+-}

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -5,6 +5,7 @@ import Database.PostgreSQL.Simple.Types (Only (..))
 import Effects
 import Import
 
+-- | Count all unique cities in the `geocode.city` database.
 cityCount :: Has Database sig m => m Int
 cityCount = do
   counts <- query_ "select count(geonameid) from geocode.city"
@@ -13,6 +14,7 @@ cityCount = do
     [Only c] -> pure c
     (Only x) : _xs -> pure x
 
+-- | Find the newest modification as downloaded from Geonames.
 latestUpdate :: Has Database sig m => m (Maybe Day)
 latestUpdate = do
   updatedAts <- query_ "select max(modification) from raw.geonames"
@@ -21,6 +23,16 @@ latestUpdate = do
     [Only u] -> pure u
     (Only u : _xs) -> pure u
 
+-- | Given an API Key, find out if it exists and is enabled.
+isKeyEnabled :: Has Database sig m => Text -> m Bool
+isKeyEnabled key = do
+  exists <- query "select true from account.api_key where key = ? and is_enabled" (Only key)
+  case exists of
+    [] -> pure False
+    [Only truth] -> pure truth
+    (Only truth : _xs) -> pure truth
+
+-- NOTES
 {- to run queries manually:
 -- stack ghci
 λ> let (DatabaseUrl url) = defaultConfig & appDatabaseUrl

--- a/src/Import.hs
+++ b/src/Import.hs
@@ -1,6 +1,7 @@
 module Import
   ( module Relude
   , module Relude.Extra.Newtype
+  , module Control.Algebra
   , headMaybe
   , lastMaybe
   ) where
@@ -9,8 +10,12 @@ module Import
 import Relude hiding (ask, runReader)
 import Relude.Extra.Newtype
 
+import Control.Algebra
+
+-- | total version of `head`
 headMaybe :: [b] -> Maybe b
 headMaybe = viaNonEmpty head
 
+-- | total version of `last`
 lastMaybe :: [b] -> Maybe b
 lastMaybe = viaNonEmpty last

--- a/src/Server/Auth.hs
+++ b/src/Server/Auth.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Server.Auth where
+
+import qualified Data.List as L
+import Import
+import Network.Wai (Request (queryString, requestHeaders))
+import Servant
+  ( Context (..),
+    ServerError (errBody),
+    err401,
+    throwError,
+  )
+import Servant.Server.Experimental.Auth
+  ( AuthHandler,
+    mkAuthHandler,
+  )
+
+newtype ApiKey = ApiKey Text
+  deriving (Eq, Show)
+
+type ApiKeyAuth = AuthHandler Request ApiKey
+
+mkApiKey :: ByteString -> ApiKey
+mkApiKey = ApiKey . decodeUtf8
+
+authHandler :: ApiKeyAuth
+authHandler =
+  mkAuthHandler handler
+  where
+    maybeToEither e = maybe (Left e) Right
+    throw401 msg = throwError $ err401 {errBody = msg}
+    extractApiKeyHeader req =
+      req
+        & requestHeaders
+        & L.lookup "x-geocode-city-api-key"
+    extractApiKeyParam req =
+      req
+        & queryString
+        & L.lookup "api-key"
+        & fromMaybe Nothing
+    handler req = either throw401 pure $ do
+      let header = maybeToEither "Missing API Key header (X-Geocode-City-Api-Key)" $ extractApiKeyHeader req
+          param = maybeToEither "Missing API Key param (api-key)" $ extractApiKeyParam req
+      case param of
+        Left _ ->
+          case header of
+            Left e -> Left e
+            Right h -> Right $ mkApiKey h
+        Right p -> Right $ mkApiKey p
+
+authContext :: Context (ApiKeyAuth ': '[])
+authContext = authHandler :. EmptyContext

--- a/src/Server/Auth.hs
+++ b/src/Server/Auth.hs
@@ -43,14 +43,9 @@ authHandler =
         & L.lookup "api-key"
         & fromMaybe Nothing
     handler req = either throw401 pure $ do
-      let header = maybeToEither "Missing API Key header (X-Geocode-City-Api-Key)" $ extractApiKeyHeader req
-          param = maybeToEither "Missing API Key param (api-key)" $ extractApiKeyParam req
-      case param of
-        Left _ ->
-          case header of
-            Left e -> Left e
-            Right h -> Right $ mkApiKey h
-        Right p -> Right $ mkApiKey p
+      extractApiKeyHeader req <|> extractApiKeyParam req
+      <&> mkApiKey
+      & maybeToEither "Missing API key header (X-Geocode-City-Api-Key) or query param (api-key)"
 
 authContext :: Context (ApiKeyAuth ': '[])
 authContext = authHandler :. EmptyContext

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -1,15 +1,24 @@
 module Server.Handlers where
 
 import Import
-import Servant
+import Servant hiding (throwError)
 import Server.Types
 import Database.Queries as Q
+import Control.Carrier.Error.Either (throwError)
+import Server.Auth
 
 service :: AppM sig m => ServerT Service m
 service = stats
 
-stats :: (AppM sig m) => m Stats
-stats = do
+stats :: (AppM sig m) => ApiKey -> m Stats
+stats apiKey = validateApiKey apiKey >> do
   count <- Q.cityCount
   update <- Q.latestUpdate
   return $ Stats update count
+
+validateApiKey :: (AppM sig m) => ApiKey -> m ()
+validateApiKey (ApiKey apiKey) = do
+  isValidKey <- Q.isKeyEnabled apiKey
+  if isValidKey
+    then pure ()
+    else throwError err403 {errBody = "Invalid API Key."}

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -3,9 +3,13 @@ module Server.Handlers where
 import Import
 import Servant
 import Server.Types
+import Database.Queries as Q
 
 service :: AppM sig m => ServerT Service m
 service = stats
 
-stats :: (AppM sig m) => m Text
-stats = pure "IMOK"
+stats :: (AppM sig m) => m Stats
+stats = do
+  count <- Q.cityCount
+  update <- Q.latestUpdate
+  return $ Stats update count

--- a/src/Server/Types.hs
+++ b/src/Server/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
@@ -11,10 +12,12 @@ import Control.Carrier.Error.Either (Throw)
 import Data.Time (Day)
 import Effects (Database, Log)
 import Data.Aeson (ToJSON)
-import Servant (Get, JSON, ServerError, type (:>))
+import Servant (AuthProtect, Get, JSON, ServerError, type (:>))
+import Servant.Server.Experimental.Auth
+import Server.Auth
 
 type Service =
-  "stats" :> Get '[JSON] Stats
+  AuthProtect "api-key" :> "stats" :> Get '[JSON] Stats
 
 type AppM sig m =
   ( Has (Log LogMessage) sig m,
@@ -32,3 +35,6 @@ data Stats = Stats
   } deriving (Eq, Show, Generic)
 
 instance ToJSON Stats
+
+-- from: https://docs.servant.dev/en/stable/tutorial/Authentication.html#generalized-authentication
+type instance AuthServerData (AuthProtect "api-key") = ApiKey

--- a/src/Server/Types.hs
+++ b/src/Server/Types.hs
@@ -1,19 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Server.Types where
 
+import Import
 import Config (LogMessage)
-import Control.Algebra (Has)
 import Control.Carrier.Error.Either (Throw)
-import Data.Time (UTCTime)
+import Data.Time (Day)
 import Effects (Database, Log)
-import Import (Int64, Text)
-import Servant (Get, PlainText, ServerError, type (:>))
+import Data.Aeson (ToJSON)
+import Servant (Get, JSON, ServerError, type (:>))
 
 type Service =
-  "stats" :> Get '[PlainText] Text
+  "stats" :> Get '[JSON] Stats
 
 type AppM sig m =
   ( Has (Log LogMessage) sig m,
@@ -26,6 +27,8 @@ type AppM sig m =
 ---
 
 data Stats = Stats
-  { lastUpdated :: UTCTime,
-    cityCount :: Int64
-  }
+  { lastUpdated :: Maybe Day,
+    cityCount :: Int
+  } deriving (Eq, Show, Generic)
+
+instance ToJSON Stats


### PR DESCRIPTION
* Introduces a simple `/stats` endpoint, gated by API key authentication.
* The Api Key can be provided via a custom header, or a querystring parameter.
* The stats endpoint exercises some queries -- showing how the `Database` effect
  contextualizes them.
    
 Some example usage:
    
 ```sh
    ~> curl -H "X-Geocode-City-Api-Key: f749532eaffa3c302e1fce7da6ad2977" http://localhost:3000/stats
    {"cityCount":196591,"lastUpdated":"2021-01-17"}
    
    ~> curl "http://localhost:3000/stats?api-key=f749532eaffa3c302e1fce7da6ad2977"
    {"cityCount":196591,"lastUpdated":"2021-01-17"}
    
    ~> curl -v "http://localhost:3000/stats?api-key=f749532eaffa3c302e1fce7da6ad2978"
    
    > GET /stats?api-key=f749532eaffa3c302e1fce7da6ad2978 HTTP/1.1
    
    > Host: localhost:3000
    > User-Agent: curl/7.64.1
    > Accept: */*
    >
    < HTTP/1.1 403 Forbidden
    < Transfer-Encoding: chunked
    < Date: Wed, 20 Jan 2021 01:21:34 GMT
    < Server: Warp/3.3.13
    <
    * Connection #0 to host localhost left intact
    Invalid API Key.
    
    ~> curl -v "http://localhost:3000/stats"
    
    > GET /stats HTTP/1.1
    > Host: localhost:3000
    > User-Agent: curl/7.64.1
    > Accept: */*
    >
    < HTTP/1.1 401 Unauthorized
    < Transfer-Encoding: chunked
    < Date: Wed, 20 Jan 2021 01:22:02 GMT
    < Server: Warp/3.3.13
    <
    * Connection #0 to host localhost left intact
    Missing API key header (X-Geocode-City-Api-Key) or query param (api-key)
 ```
