### PR TITLE
Basic Swagger support

### DIFF
--- a/geocode-city-api.cabal
+++ b/geocode-city-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6c1737b57e041bdbc6f8f246421008943a7806ca6b57c8914c33fd5e9bc9f6eb
+-- hash: 2ea8f7adc7a9fef85e5db756fcdf9773275548c6dd015922fa1cc82c36e25a0e
 
 name:           geocode-city-api
 version:        0.1.0.0
@@ -54,6 +54,7 @@ library
     , fused-effects >=1.1.1.0 && <1.2
     , http-api-data
     , http-types
+    , lens
     , optparse-applicative
     , postgresql-simple
     , postgresql-simple-migration
@@ -62,6 +63,7 @@ library
     , servant
     , servant-server
     , servant-swagger
+    , swagger2
     , text
     , time
     , wai
@@ -86,6 +88,7 @@ executable geocode-city-api-exe
     , geocode-city-api
     , http-api-data
     , http-types
+    , lens
     , optparse-applicative
     , postgresql-simple
     , postgresql-simple-migration
@@ -94,6 +97,7 @@ executable geocode-city-api-exe
     , servant
     , servant-server
     , servant-swagger
+    , swagger2
     , text
     , time
     , wai
@@ -126,6 +130,7 @@ test-suite geocode-city-api-test
     , hspec-wai-json
     , http-api-data
     , http-types
+    , lens
     , optparse-applicative
     , postgresql-simple
     , postgresql-simple-migration
@@ -134,6 +139,7 @@ test-suite geocode-city-api-test
     , servant
     , servant-server
     , servant-swagger
+    , swagger2
     , text
     , time
     , wai

--- a/geocode-city-api.cabal
+++ b/geocode-city-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2ea8f7adc7a9fef85e5db756fcdf9773275548c6dd015922fa1cc82c36e25a0e
+-- hash: 525eaceaf2e2d5cc83f923332a87f464440a973b44bfca60b8e8cce1368f11e3
 
 name:           geocode-city-api
 version:        0.1.0.0
@@ -63,7 +63,7 @@ library
     , servant
     , servant-server
     , servant-swagger
-    , swagger2
+    , swagger2 >=2.5 && <2.6
     , text
     , time
     , wai
@@ -97,7 +97,7 @@ executable geocode-city-api-exe
     , servant
     , servant-server
     , servant-swagger
-    , swagger2
+    , swagger2 >=2.5 && <2.6
     , text
     , time
     , wai
@@ -139,7 +139,7 @@ test-suite geocode-city-api-test
     , servant
     , servant-server
     , servant-swagger
-    , swagger2
+    , swagger2 >=2.5 && <2.6
     , text
     , time
     , wai

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - servant
 - servant-server
 - servant-swagger
+- swagger2
 - aeson
 - text
 - wai
@@ -40,6 +41,7 @@ dependencies:
 - optparse-applicative
 - resource-pool ^>= 0.2.3.2
 - containers
+- lens
 
 ghc-options:
 - -Wall

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
 - servant
 - servant-server
 - servant-swagger
-- swagger2
+- swagger2 ^>= 2.5
 - aeson
 - text
 - wai

--- a/src/Server/Auth.hs
+++ b/src/Server/Auth.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Server.Auth where
 
@@ -9,7 +12,7 @@ import qualified Data.List as L
 import Import
 import Network.Wai (Request (queryString, requestHeaders))
 import Servant
-  ( Context (..),
+  ((:>), AuthProtect,  Context (..),
     ServerError (errBody),
     err401,
     throwError,
@@ -18,6 +21,18 @@ import Servant.Server.Experimental.Auth
   ( AuthHandler,
     mkAuthHandler,
   )
+import qualified Control.Lens as L
+import Data.Swagger
+  ( ApiKeyLocation (..),
+    ApiKeyParams (..),
+    SecurityRequirement (..),
+    SecurityScheme (..),
+    SecuritySchemeType (..),
+    allOperations,
+    security,
+    securityDefinitions,
+  )
+import Servant.Swagger
 
 newtype ApiKey = ApiKey Text
   deriving (Eq, Show)
@@ -49,3 +64,25 @@ authHandler =
 
 authContext :: Context (ApiKeyAuth ': '[])
 authContext = authHandler :. EmptyContext
+
+---
+--- Swagger instances
+---
+
+-- from:
+-- https://hackage.haskell.org/package/servant-auth-swagger-0.2.10.1/docs/src/Servant.Auth.Swagger.html#local-6989586621679074700
+-- and:
+-- https://stackoverflow.com/questions/59620798/how-are-generalized-authentication-combinators-documented-with-swagger2-and-serv
+
+instance HasSwagger api => HasSwagger (AuthProtect "api-key" :> api) where
+  toSwagger _ =
+    toSwagger (Proxy :: Proxy api)
+      L.& securityDefinitions L.<>~ mkSec (fromList secs)
+      L.& allOperations . security L.<>~ secReqs
+    where
+      secs = [("ApiKeyAuth", securityScheme)]
+      secReqs = [SecurityRequirement (fromList [(s, [])]) | (s, _) <- secs]
+      mkSec = id
+      securityScheme = SecurityScheme type_ (Just desc)
+      type_ = SecuritySchemeApiKey (ApiKeyParams "api-key" ApiKeyQuery)
+      desc = "JSON Web Token-based API key (can also be provided in the X-Geocode-City-Api-Key header)"

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -6,9 +6,12 @@ import Server.Types
 import Database.Queries as Q
 import Control.Carrier.Error.Either (throwError)
 import Server.Auth
+import Control.Lens ((.~), (?~))
+import Data.Swagger
+import Servant.Swagger
 
 service :: AppM sig m => ServerT Service m
-service = stats
+service = return swaggerSpec :<|> stats
 
 stats :: (AppM sig m) => ApiKey -> m Stats
 stats apiKey = validateApiKey apiKey >> do
@@ -22,3 +25,18 @@ validateApiKey (ApiKey apiKey) = do
   if isValidKey
     then pure ()
     else throwError err403 {errBody = "Invalid API Key."}
+
+---
+--- Swagger
+---
+
+swaggerSpec :: Swagger
+swaggerSpec =
+  toSwagger proxyApi
+    & info . title .~ "Geocode.city API"
+    & info . version .~ "1.0"
+    & info . description ?~ "City-only geocoding"
+
+-- | Output generated @swagger.json@ file for the @'TodoAPI'@.
+-- writeSwaggerJSON :: IO ()
+-- writeSwaggerJSON = BL8.writeFile "example/swagger.json" (encodePretty todoSwagger)

--- a/src/Server/Run.hs
+++ b/src/Server/Run.hs
@@ -25,12 +25,10 @@ import Import
 import qualified Network.Wai.Handler.Warp as Warp
 import Servant (Application, HasServer (hoistServerWithContext), serveWithContext, throwError)
 import Server.Handlers (service)
-import Server.Types (Service)
+import Server.Types (proxyService)
 import Server.Auth (ApiKeyAuth, authContext)
 
-proxyService :: Proxy Service
-proxyService = Proxy
-
+-- | Build a wai app with a connection pool
 application :: P.Pool PG.Connection -> Application
 application pool =
   serveWithContext proxyService authContext $

--- a/src/Server/Types.hs
+++ b/src/Server/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Server.Types where
 
@@ -12,19 +13,28 @@ import Control.Carrier.Error.Either (Throw)
 import Data.Time (Day)
 import Effects (Database, Log)
 import Data.Aeson (ToJSON)
-import Servant (AuthProtect, Get, JSON, ServerError, type (:>))
+import Servant (AuthProtect, Get, JSON, ServerError, (:<|>), type (:>))
 import Servant.Server.Experimental.Auth
 import Server.Auth
+import Data.Swagger
 
-type Service =
+type ApiRoutes =
   AuthProtect "api-key" :> "stats" :> Get '[JSON] Stats
 
+type SwaggerAPI = "swagger.json" :> Get '[JSON] Swagger
+
+type Service = SwaggerAPI :<|> ApiRoutes
 type AppM sig m =
   ( Has (Log LogMessage) sig m,
     Has (Throw ServerError) sig m,
     Has Database sig m
   )
 
+proxyService :: Proxy Service
+proxyService = Proxy
+
+proxyApi :: Proxy ApiRoutes
+proxyApi = Proxy
 ---
 --- RESPONSE TYPES
 ---
@@ -32,9 +42,11 @@ type AppM sig m =
 data Stats = Stats
   { lastUpdated :: Maybe Day,
     cityCount :: Int
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Show, Generic, Typeable)
 
 instance ToJSON Stats
 
 -- from: https://docs.servant.dev/en/stable/tutorial/Authentication.html#generalized-authentication
 type instance AuthServerData (AuthProtect "api-key") = ApiKey
+
+instance ToSchema Stats


### PR DESCRIPTION
* Adds a `/swagger.json` route that can be used by any swagger UI
* Adds a Swagger instance for ApiKey auth

Importing the output of `/swagger.json` into [Swagger Editor](editor.swagger.io) produces:

![image](https://user-images.githubusercontent.com/82133/105119804-0e3b4f80-5a9f-11eb-825c-82d8da91299f.png)

The question for the near future is: where to serve this? Here, alongside a small demo page? A GH page? (The latter, which would exercise CORS and not pollute the API with static serving, sounds better -- maybe even have `/` redirect to said page)

## References

* https://github.com/haskell-servant/servant-swagger/blob/1909e44e965dca24cb1f5cee4b08c0781dfdbff6/example/src/Todo.hs
* https://github.com/haskell-servant/servant-swagger/tree/1909e44e965dca24cb1f5cee4b08c0781dfdbff6
* https://hackage.haskell.org/package/servant-auth-swagger-0.2.10.1/docs/src/Servant.Auth.Swagger.html