### PR TITLE
Basic rate limiting

### DIFF
--- a/geocode-city-api.cabal
+++ b/geocode-city-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 525eaceaf2e2d5cc83f923332a87f464440a973b44bfca60b8e8cce1368f11e3
+-- hash: 5d0596bb832674fa5ce623837a77f59bb8ffde9e470b037e2efa79949410c210
 
 name:           geocode-city-api
 version:        0.1.0.0
@@ -32,8 +32,10 @@ library
       Database.Pool
       Database.Queries
       Effects
+      Effects.Cache
       Effects.Database
       Effects.Log
+      Effects.Time
       Import
       Server.Auth
       Server.Handlers
@@ -52,6 +54,7 @@ library
     , containers
     , envy
     , fused-effects >=1.1.1.0 && <1.2
+    , hedis
     , http-api-data
     , http-types
     , lens
@@ -86,6 +89,7 @@ executable geocode-city-api-exe
     , envy
     , fused-effects >=1.1.1.0 && <1.2
     , geocode-city-api
+    , hedis
     , http-api-data
     , http-types
     , lens
@@ -125,6 +129,7 @@ test-suite geocode-city-api-test
     , envy
     , fused-effects >=1.1.1.0 && <1.2
     , geocode-city-api
+    , hedis
     , hspec
     , hspec-wai
     , hspec-wai-json

--- a/migrations/202101231600_api_quotas.sql
+++ b/migrations/202101231600_api_quotas.sql
@@ -1,0 +1,2 @@
+alter table account.api_key
+  add column if not exists monthly_quota bigint default 100000;

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
 - resource-pool ^>= 0.2.3.2
 - containers
 - lens
+- hedis
 
 ghc-options:
 - -Wall

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -35,11 +35,15 @@ newtype DatabaseUrl = DatabaseUrl Text
   deriving newtype (Eq, Show)
   deriving (Var) via Text
 
+newtype RedisUrl = RedisUrl String
+  deriving newtype (Eq, Show)
+  deriving (Var) via String
 -- | Configuration as it comes from the environment; flat, static.
 data AppConfig = AppConfig
   { appPort :: !Int,
     appDeployEnv :: !Environment,
-    appDatabaseUrl :: !DatabaseUrl
+    appDatabaseUrl :: !DatabaseUrl,
+    appRedisUrl    :: !RedisUrl
   }
   deriving stock (Eq, Show, Generic)
 
@@ -60,7 +64,10 @@ defaultConfig =
   AppConfig
     { appPort = 3000,
       appDeployEnv = Development,
-      appDatabaseUrl = DatabaseUrl "postgresql://localhost/geocode_city_dev?user=luis"
+      appDatabaseUrl = DatabaseUrl "postgresql://localhost/geocode_city_dev?user=luis",
+      -- the underlying lib can parse the right stuff here:
+      -- https://hackage.haskell.org/package/hedis-0.14.1/docs/Database-Redis.html#v:parseConnectInfo
+      appRedisUrl = RedisUrl "redis://"
     }
 
 -- | Log levels

--- a/src/Database/Migrations.hs
+++ b/src/Database/Migrations.hs
@@ -5,8 +5,6 @@ import Database.PostgreSQL.Simple (connectPostgreSQL, withTransaction)
 import Database.PostgreSQL.Simple.Migration (MigrationCommand (..), MigrationContext (..), MigrationResult (..), runMigration)
 import Import
 
--- TODO(luis) we may want to take a Bool parameter to send
--- in `MigrationContext`: right now it defaults to verbose.
 runMigrations' :: Bool -> FilePath -> DatabaseUrl -> IO (Either String String)
 runMigrations' isVerbose migrationsDir (DatabaseUrl conStr) = do
   con <- connectPostgreSQL $ encodeUtf8 conStr

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -56,11 +56,12 @@ latestUpdate = do
   updatedAts <- query_ "select max(modification) from raw.geonames"
   pure $ fromOnly =<< listToMaybe updatedAts
 
--- | Given an API Key, find out if it exists and is enabled.
-isKeyEnabled :: Has Database sig m => Text -> m Bool
-isKeyEnabled key = do
-  exists <- query "select is_enabled from account.api_key where key = ?" (Only key)
-  pure $ maybe False fromOnly (listToMaybe exists)
+-- | Given an API Key, find out if it exists and is enabled;
+-- return status and current quota.
+findApiKey :: Has Database sig m => Text -> m (Bool, Maybe Integer)
+findApiKey key = do
+  exists <- query "select is_enabled, monthly_quota from account.api_key where key = ?" (Only key)
+  pure $ fromMaybe (False, Just 0) (listToMaybe exists)
 
 
 -- | Fast query for name autocomplete: biased towards more populous cities,

--- a/src/Effects.hs
+++ b/src/Effects.hs
@@ -1,9 +1,15 @@
 module Effects
   ( module Effects.Log
   , module Effects.Database
+  , module Effects.Time
+  , module Effects.Cache
   )
 where
 
 import Effects.Log
 
 import Effects.Database
+--
+import Effects.Cache
+--
+import Effects.Time

--- a/src/Effects/Cache.hs
+++ b/src/Effects/Cache.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Effects.Cache where
+
+import Control.Algebra
+import Control.Carrier.Error.Either (ErrorC, Throw, runError)
+import Control.Carrier.Reader
+import Control.Carrier.Throw.Either (throwError)
+import qualified Database.Redis as R
+import Import
+
+---
+
+data Cache (m :: Type -> Type) k where
+  HllAdd :: ByteString -> [ByteString] -> Cache m Integer
+  HllCount :: [ByteString] -> Cache m Integer
+
+hllAdd :: (Has Cache sig m) => ByteString -> [ByteString] -> m Integer
+hllAdd key values = send $ HllAdd key values
+
+hllCount :: (Has Cache sig m) => [ByteString] -> m Integer
+hllCount = send . HllCount
+
+newtype CacheIOC m a = CacheIOC {runCacheIO :: ReaderC R.Connection m a}
+  deriving (Applicative, Functor, Monad, MonadIO)
+
+newtype CacheError = CacheError R.Reply
+  deriving (Eq, Show)
+
+runCacheWithConnection :: R.Connection -> CacheIOC m hs -> m hs
+runCacheWithConnection conn = runReader conn . runCacheIO
+
+instance
+  (Has (Throw CacheError) sig m, MonadIO m, Algebra sig m) =>
+  Algebra (Cache :+: sig) (CacheIOC m)
+  where
+  alg hdl sig ctx = CacheIOC $ case sig of
+    L (HllAdd key values) -> do
+      conn <- ask
+      added <- liftIO $
+        R.runRedis conn $ do
+          R.pfadd key values
+      (<$ ctx) <$> either (throwError . CacheError) pure added
+    L (HllCount keys) -> do
+      conn <- ask
+      count <- liftIO $
+        R.runRedis conn $ do
+          R.pfcount keys
+      (<$ ctx) <$> either (throwError . CacheError) pure count
+    R other -> alg (runCacheIO . hdl) (R other) ctx
+
+runCacheEither :: ErrorC CacheError m a -> m (Either CacheError a)
+runCacheEither = runError @CacheError

--- a/src/Effects/Time.hs
+++ b/src/Effects/Time.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Effects.Time where
+
+import Control.Algebra
+import Data.Time (UTCTime, getCurrentTime)
+import Import
+
+data Time (m :: Type -> Type) k where
+  Now :: Time m UTCTime
+
+now :: (Has Time sig m) => m UTCTime
+now = send Now
+
+newtype TimeIOC m a = TimeIOC {runTimeIO :: m a}
+  deriving (Applicative, Functor, Monad, MonadIO)
+
+instance
+  (MonadIO m, Algebra sig m) =>
+  Algebra (Time :+: sig) (TimeIOC m)
+  where
+  alg hdl sig ctx = case sig of
+    L Now -> (<$ ctx) <$> liftIO getCurrentTime
+    R other -> TimeIOC $ alg (runTimeIO . hdl) other ctx

--- a/src/Server/Auth.hs
+++ b/src/Server/Auth.hs
@@ -34,6 +34,7 @@ import Data.Swagger
   )
 import Servant.Swagger
 import qualified Data.ByteString.Char8 as B8
+import Data.Char (isSpace)
 
 newtype ApiKey = ApiKey Text
   deriving (Eq, Show)
@@ -80,18 +81,30 @@ maybeToEither e = maybe (Left e) Right
 mkApiKey :: ByteString -> ApiKey
 mkApiKey = ApiKey . decodeUtf8
 
--- TODO: maybe generate a random UUID? This is only really
--- useful for dev/test, when it's annoying to set `x-request-id`
--- by hand
-mkRequestId :: Maybe ByteString -> Maybe RequestID
-mkRequestId Nothing = Just . RequestID $ "fake-id"
-mkRequestId rid = RequestID <$> rid 
-
-getLastIP :: ByteString -> Maybe IPAddress
-getLastIP bs =
-  B8.split ',' bs
-    & lastMaybe
-    <&> IPAddress
+-- | Given a bytestring containing potentially many ip addresses
+-- separated by commas, get the last (or only) one.
+--
+-- HEROKU SANS PROXY SPECIFIC:
+-- Note that getting the last IP, in the case of multiple addresses
+-- being present (due to spoofing or proxies) isn't _fully_ reliable:
+-- Heroku appends the IP _it_ saw as connecting to their origin to
+-- the `x-forwarded-for` header, which means the last one is likely
+-- the real one even in the presence of spoofing; but if a proxy sits
+-- in front of Heroku (e.g. Fastly,) then that one will end up in the
+-- last position, as is canonical for the header:
+-- https://stackoverflow.com/a/37061471
+-- https://en.wikipedia.org/wiki/X-Forwarded-For
+-- in our case though, when most traffic will fall within the only-one-IP
+-- or many-IPs-but-likely-spoofing scenario, this is good enough.
+mkIpAddress :: ByteString -> Maybe IPAddress
+mkIpAddress bs = do
+  let addresses = B8.split ',' bs
+  case addresses of
+    [ip] -> pure . IPAddress $ ip
+    l@(_:_ips) -> do
+      lastIP <- lastMaybe l
+      pure . IPAddress $ B8.dropWhile isSpace lastIP
+    _    -> Nothing
 
 -- | Find API Key in @X-Geocode-City-Api-Key@ header
 extractApiKeyHeader :: Request -> Maybe ByteString
@@ -108,30 +121,39 @@ extractApiKeyParam req =
     & L.lookup "api-key"
     & fromMaybe Nothing
 
--- Both x-request-id and x-forwarded-for are Heroku-isms;
--- they're not reliable (or set!) in other environments
--- but we only use them to identify requests (not authenticate/authorize.)
--- | Extract request ID from `x-request-id` header. Default to  
+
+-- | Extract request ID from `x-request-id` header:
+-- https://devcenter.heroku.com/articles/http-request-id
 extractRequestId :: Request -> Maybe RequestID
 extractRequestId req =
   req
     & requestHeaders
     & L.lookup "x-request-id"
-    & mkRequestId
+    <&> RequestID 
 
+-- | The request IP is the "real" IP as populated by Heroku:
+-- https://devcenter.heroku.com/articles/http-routing#heroku-headers
+-- there's also [remoteHost](https://hackage.haskell.org/package/wai-3.2.3/docs/Network-Wai.html#v:remoteHost)
+-- but that's unusable in production.
 extractRequestIP :: Request -> Maybe IPAddress
 extractRequestIP req =
   req
     & requestHeaders
     & L.lookup "x-forwarded-for"
-    <&> getLastIP
+    <&> mkIpAddress
     & fromMaybe Nothing
+
+-- | Attempt to extract the api key from the request: either from our custom header, or the querystring.
 authWithApiKey :: Request -> Maybe RequestKey
 authWithApiKey req = do
   apiKey <- mkApiKey <$> (extractApiKeyHeader req <|> extractApiKeyParam req)
   requestID <- extractRequestId req
   pure $ ByApiKey apiKey requestID
 
+-- | Identify a request by IP. This is a very Heroku-centric approach: we rely
+-- on the x-request-id and x-forwarded-for headers; we _could_ use
+-- wai's `remoteHost` as a fallback, but it's unrealistic in the current
+-- deployment environment: it's either populated upstream, or not.
 authWithIP :: Request -> Maybe RequestKey
 authWithIP req = do
   ip <- extractRequestIP req
@@ -158,4 +180,4 @@ instance HasSwagger api => HasSwagger (AuthProtect "api-key" :> api) where
       mkSec = id
       securityScheme = SecurityScheme type_ (Just desc)
       type_ = SecuritySchemeApiKey (ApiKeyParams "api-key" ApiKeyQuery)
-      desc = "JSON Web Token-based API key (can also be provided in the X-Geocode-City-Api-Key header)"
+      desc = "JSON Web Token-based API key (can also be provided in the X-Geocode-City-Api-Key header.) If omitted, the client IP will be used for rate limiting."

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -8,11 +8,11 @@ import Database.Queries as Q
 import Control.Carrier.Error.Either (throwError)
 import Server.Auth
 import Control.Lens ((.~), (?~))
-import Data.Swagger
+import Data.Swagger hiding (Info)
 import Servant.Swagger
 import Data.Time
-import Effects.Cache
-import Effects.Time (now)
+import Config (LogMessage (..))
+import Effects (hllAdd, hllCount, log, now)
 
 service :: AppM sig m => ServerT Service m
 service =
@@ -82,6 +82,10 @@ validateApiKey (ByIP (IPAddress ipAddress) (RequestID requestId)) = do
   else
     throwError err429 {errBody = "Daily request limit exceeded for IP Address (try using an API Key)."}
 
+-- | If given "unlimited access", don't do any rate limiting.
+validateApiKey WithUnlimitedAccess = do
+  log $ Info "Request without rate limiting"
+  pure ()
 
 err429 :: ServerError
 err429 = 

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -10,6 +10,8 @@ import Server.Auth
 import Control.Lens ((.~), (?~))
 import Data.Swagger
 import Servant.Swagger
+import Data.Time
+import Effects.Cache
 
 service :: AppM sig m => ServerT Service m
 service =
@@ -27,6 +29,8 @@ stats apiKey = validateApiKey apiKey >> do
 
 validateApiKey :: (AppM sig m) => ApiKey -> m ()
 validateApiKey (ApiKey apiKey) = do
+  -- example use, not really anything to write home about yet
+  count <- hllAdd "a" ["b"]
   isValidKey <- Q.isKeyEnabled apiKey
   if isValidKey
     then pure ()
@@ -97,3 +101,9 @@ serializeCityResult Q.CityQ {..} =
       elevation = cElevation,
       population = cPopulation
     }
+
+hourString :: UTCTime -> String
+hourString = formatTime defaultTimeLocale "%Y-%m-%dT%H"
+
+monthString :: UTCTime -> String
+monthString = formatTime defaultTimeLocale "%Y-%m-%d"

--- a/src/Server/Handlers.hs
+++ b/src/Server/Handlers.hs
@@ -13,6 +13,8 @@ import Servant.Swagger
 import Data.Time
 import Config (LogMessage (..))
 import Effects (hllAdd, hllCount, log, now)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import qualified Network.HTTP.Types as N
 
 service :: AppM sig m => ServerT Service m
 service =
@@ -22,70 +24,89 @@ service =
     :<|> search
     :<|> reverseGeocode
 
-stats :: (AppM sig m) => RequestKey -> m Stats
-stats apiKey = validateApiKey apiKey >> do
+stats :: (AppM sig m) => RequestKey -> m (RateLimited Stats)
+stats apiKey = do
+  rateLimitInfo <- checkUsage apiKey
   count <- Q.cityCount
   update <- Q.latestUpdate
-  return $ Stats update count
+  return $ addRateLimitHeaders rateLimitInfo $ Stats update count
 
-autoComplete :: (AppM sig m) => RequestKey -> Text -> Maybe Int -> m [CityAutocomplete]
-autoComplete apiKey q limit =
-  validateApiKey apiKey >> do
-    results <- Q.cityAutoComplete q limit
-    return $ map serializeAutocompleteResult results
+autoComplete :: (AppM sig m) => RequestKey -> Text -> Maybe Int -> m (RateLimited [CityAutocomplete])
+autoComplete apiKey q limit = do
+  rateLimitInfo <- checkUsage apiKey
+  results <- Q.cityAutoComplete q limit
+  return $ addRateLimitHeaders rateLimitInfo $ map serializeAutocompleteResult results
 
 -- | Search city by name
-search :: (AppM sig m) => RequestKey -> Text -> Maybe Int -> m [City]
-search apiKey q limit =
-  validateApiKey apiKey >> do
-    results <- Q.citySearch q limit
-    return $ map serializeCityResult results
+search :: (AppM sig m) => RequestKey -> Text -> Maybe Int -> m (RateLimited [City])
+search apiKey q limit = do
+  rateLimitInfo <- checkUsage apiKey
+  results <- Q.citySearch q limit
+  return $ addRateLimitHeaders rateLimitInfo $ map serializeCityResult results
 
 -- | Search city by (lat, lng)
-reverseGeocode :: (AppM sig m) => RequestKey -> Latitude -> Longitude -> Maybe Int -> m [City]
-reverseGeocode apiKey lat lng limit =
-  validateApiKey apiKey >> do
-    results <- Q.reverseSearch (lng, lat) limit
-    return $ map serializeCityResult results
+reverseGeocode :: (AppM sig m) => RequestKey -> Latitude -> Longitude -> Maybe Int -> m (RateLimited [City])
+reverseGeocode apiKey lat lng limit = do
+  rateLimitInfo <- checkUsage apiKey
+  results <- Q.reverseSearch (lng, lat) limit
+  return $ addRateLimitHeaders rateLimitInfo $ map serializeCityResult results
 
 ---
 --- Rate Limiting
 ---
-
--- TODO: return requests left in quota, rate limit reset timestamp
-
 -- | Rate limit based on api key: must be valid and under allocated quota in the current (UTC) month
-validateApiKey :: (AppM sig m) => RequestKey -> m ()
-validateApiKey (ByApiKey (ApiKey apiKey) (RequestID requestId)) = do
+-- note that a given key may not have any quota set: we currently interpret that
+-- scenario as "unlimited" and return headers indicating that, just like `WithUnlimitedAccess`
+checkUsage :: (AppM sig m) => RequestKey -> m RateLimitInfo
+checkUsage (ByApiKey (ApiKey apiKey) (RequestID requestId)) = do
   currentTime <- now
-  let cacheKey = "requests:" <> encodeUtf8 apiKey <> encodeUtf8 (monthString currentTime)
+  let cacheKey = "requests:" <> encodeUtf8 apiKey <> ":" <> encodeUtf8 (monthString currentTime)
   _added <- hllAdd cacheKey [requestId]
   count <- hllCount [cacheKey]
-  -- TODO: retrieve quota from DB
-  isValidKey <- Q.isKeyEnabled apiKey
+  (isValidKey, quota) <- Q.findApiKey apiKey
+  let limit     = fromMaybe 0 quota
+      remaining = max 0 (limit - count)
+      resetsAt  = case quota of
+        Just _ -> nextMonthStart currentTime
+        Nothing -> currentTime
+      rateLimitInfo = RateLimitInfo limit remaining (resetsAt & utcTimeToPOSIXSeconds)
   if isValidKey
     then
-      if count < 100000 then
-        pure ()
+      -- no quota means unlimited (!)
+      if maybe True (count <) quota  then
+        pure rateLimitInfo
       else
-        throwError err429 {errBody = "Monthly request limit exceeded for API Key."}
+        throwError
+          err429
+            { errBody = "Monthly request limit exceeded for API Key.",
+              errHeaders = rateLimitHeaders rateLimitInfo
+            }
     else throwError err403 {errBody = "Invalid API Key."}
 
 -- | Rate-limit based on (real) IP: must be under 1000 requests in the current (UTC) day
-validateApiKey (ByIP (IPAddress ipAddress) (RequestID requestId)) = do
+checkUsage (ByIP (IPAddress ipAddress) (RequestID requestId)) = do
   currentTime <- now
-  let cacheKey = "requests:" <> ipAddress <> encodeUtf8 (dayString currentTime)
+  let cacheKey = "requests:" <> ipAddress <> ":" <> encodeUtf8 (dayString currentTime)
   _added <- hllAdd cacheKey [requestId]
   count <- hllCount [cacheKey]
-  if count < 1000 then
-    pure ()
+  let limit = 1000
+      remaining = max 0 (limit - count)
+      resetsAt  = nextDayStart currentTime
+      rateLimitInfo = RateLimitInfo limit remaining (resetsAt & utcTimeToPOSIXSeconds)
+  if count < limit then
+    pure rateLimitInfo
   else
-    throwError err429 {errBody = "Daily request limit exceeded for IP Address (try using an API Key)."}
+    throwError
+      err429
+        { errBody = "Daily request limit exceeded for IP Address (try using an API Key).",
+          errHeaders = rateLimitHeaders rateLimitInfo
+        }
 
 -- | If given "unlimited access", don't do any rate limiting.
-validateApiKey WithUnlimitedAccess = do
-  log $ Info "Request without rate limiting"
-  pure ()
+checkUsage WithUnlimitedAccess = do
+  log $ Info "Request without rate limiting!"
+  currentTime <- now
+  pure $ RateLimitInfo 0 0 (currentTime & utcTimeToPOSIXSeconds)
 
 err429 :: ServerError
 err429 = 
@@ -95,6 +116,21 @@ err429 =
                     , errHeaders = []
                     }
 
+rateLimitHeaders :: RateLimitInfo -> [N.Header]
+rateLimitHeaders RateLimitInfo {..} =
+  [ ("X-RateLimit-Limit", encodeUtf8 . showString $ rateLimitTotal),
+    ("X-RateLimit-Remaining", encodeUtf8 . showString $ rateLimitRemaining),
+    ("X-RateLimit-Resets", encodeUtf8 . showString $ rateLimitResets)
+  ]
+  where
+    showString :: Show a => a -> String
+    showString = show
+
+addRateLimitHeaders :: RateLimitInfo -> a -> RateLimited a
+addRateLimitHeaders RateLimitInfo {..} =
+  addHeader rateLimitTotal
+    . addHeader rateLimitRemaining
+    . addHeader rateLimitResets
 ---
 --- Swagger
 ---
@@ -147,3 +183,13 @@ dayString = formatTime defaultTimeLocale "%Y-%m-%d"
 
 monthString :: UTCTime -> String
 monthString = formatTime defaultTimeLocale "%Y-%m"
+
+nextDayStart :: UTCTime -> UTCTime
+nextDayStart (UTCTime day _time) = UTCTime (addDays 1 day) 0
+
+nextMonthStart :: UTCTime -> UTCTime
+nextMonthStart (UTCTime day _time) =
+  UTCTime monthStart 0
+  where
+    (y, m, _d) = toGregorian $ addGregorianMonthsClip 1 day
+    monthStart = fromGregorian y m 1

--- a/src/Server/Run.hs
+++ b/src/Server/Run.hs
@@ -64,5 +64,6 @@ handleError err =
 start :: AppConfig -> IO ()
 start cfg = do
   pool <- DB.initPool (appDatabaseUrl cfg)
+  -- TODO: get REDIS_URL from config, parse (and fail if parsing fails)
   redis <- R.checkedConnect R.defaultConnectInfo 
   Warp.run (appPort cfg) (application redis pool)

--- a/src/Server/Types.hs
+++ b/src/Server/Types.hs
@@ -13,7 +13,7 @@ import Import
 import Config (LogMessage)
 import Control.Carrier.Error.Either (Throw)
 import Data.Time (Day)
-import Effects (Database, Log)
+import Effects (Cache, Database, Log, Time)
 import Data.Aeson
   ( Options (fieldLabelModifier),
     ToJSON (toJSON),
@@ -49,7 +49,9 @@ type Service = SwaggerAPI :<|> ApiRoutes
 type AppM sig m =
   ( Has (Log LogMessage) sig m,
     Has (Throw ServerError) sig m,
-    Has Database sig m
+    Has Database sig m,
+    Has Time sig m,
+    Has Cache sig m
   )
 
 proxyService :: Proxy Service

--- a/src/Server/Types.hs
+++ b/src/Server/Types.hs
@@ -62,7 +62,7 @@ proxyApi = Proxy
 
 -- | Auth type for api keys
 -- from: https://docs.servant.dev/en/stable/tutorial/Authentication.html#generalized-authentication
-type instance AuthServerData (AuthProtect "api-key") = ApiKey
+type instance AuthServerData (AuthProtect "api-key") = RequestKey
 
 ---
 --- REQUEST TYPES


### PR DESCRIPTION
Closes #10 -- in a way.

Uses redis's hyperloglog to count unique requests per IP/Api Key. This is _usage_ rate limiting, no throttling (yet) -- when we want that, there seems to be [middleware for that](https://hackage.haskell.org/package/wai-middleware-throttle-0.3.0.1/docs/Network-Wai-Middleware-Throttle.html) that uses Leaky Bucket.

* Introduces the `Cache` effect, assuming Redis is provisioned (via `REDIS_URL`)
* Introduces the `Time` effect, for, er, time!
* Introduces the notion of `RequestKey` to identify a request: by ip, by api key, and "unlimited access" as a bit of  dev/test
  escape hatch: no rate limiting is applied, but it's only enabled in production!